### PR TITLE
Breedsの一覧を取得するためのRepositoryの実装

### DIFF
--- a/lib/domain/breed.dart
+++ b/lib/domain/breed.dart
@@ -1,0 +1,15 @@
+class Breed {
+  const Breed({
+    required this.breed,
+    required this.country,
+    required this.origin,
+    required this.coat,
+    required this.pattern,
+  });
+
+  final String breed;
+  final String country;
+  final String origin;
+  final String coat;
+  final String pattern;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,37 @@
+import 'dart:developer';
 import 'package:flutter/material.dart';
+import 'package:flutter_cat_breeds/model/cat_breeds_repository.dart';
 
 void main() {
   runApp(const MainApp());
 }
 
-class MainApp extends StatelessWidget {
+class MainApp extends StatefulWidget {
   const MainApp({super.key});
+
+  @override
+  State<MainApp> createState() => _MainAppState();
+}
+
+class _MainAppState extends State<MainApp> {
+  final repo = BreedsRepository();
+  @override
+  void initState() {
+    super.initState();
+    Future(() async {
+      final list = await repo.getBreeds();
+      for (final entry in list.asMap().entries) {
+        final index = entry.key; // インデックス
+        final element = entry.value; // 要素
+
+        log('$index: ${element.breed}');
+        log('$index: ${element.country}');
+        log('$index: ${element.origin}');
+        log('$index: ${element.coat}');
+        log('$index: ${element.pattern}');
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/model/cat_breeds_repository.dart
+++ b/lib/model/cat_breeds_repository.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+
+import 'package:flutter_cat_breeds/domain/breed.dart';
+import 'package:flutter_cat_breeds/model/cat_breeds_response.dart';
+import 'package:flutter_cat_breeds/util/http_client.dart';
+import 'package:flutter_cat_breeds/util/http_request_setting.dart';
+
+class BreedsRequestSetting implements HttpRequestSetting<List<Breed>> {
+  BreedsRequestSetting({this.limit = 10, this.page});
+
+  final int limit;
+  final int? page;
+
+  @override
+  List<Breed> decode(dynamic data) {
+    final map = json.decode(data) as Map<String, dynamic>;
+    final dto = BreedsResponse.fromJson(map);
+
+    final list = dto.data
+        .map(
+          (e) => Breed(
+            breed: e.breed,
+            country: e.country,
+            origin: e.origin,
+            coat: e.coat,
+            pattern: e.pattern,
+          ),
+        )
+        .toList();
+
+    return list;
+  }
+
+  @override
+  HttpRequestEndpoint get endpoint => HttpRequestEndpoint(
+        host: 'https://catfact.ninja',
+        path: '/breeds',
+      );
+
+  @override
+  Future<Map<String, String>> headers() => Future(
+        () => {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+      );
+
+  @override
+  HttpRequestMethod get method => HttpRequestMethod.get;
+
+  @override
+  Future<Map<String, dynamic>> parameters() async {
+    final params = <String, dynamic>{
+      'limit': limit,
+    };
+    if (page != null) {
+      params['page'] = page;
+    }
+    return params;
+  }
+}
+
+class BreedsRepository {
+  Future<List<Breed>> getBreeds() async {
+    return HttpClient().request(setting: BreedsRequestSetting());
+  }
+}

--- a/lib/model/cat_breeds_response.dart
+++ b/lib/model/cat_breeds_response.dart
@@ -6,12 +6,12 @@ part '../_generated/model/cat_breeds_response.g.dart';
 @freezed
 class BreedsResponse with _$BreedsResponse {
   const factory BreedsResponse({
-    @JsonKey(name: 'data') required List<Breed> data,
+    @JsonKey(name: 'data') required List<BreedResponse> data,
     @JsonKey(name: 'current_page') required int currentPage,
     @JsonKey(name: 'last_page') required int lastPage,
     @JsonKey(name: 'per_page') required int perPage,
     @JsonKey(name: 'total') required int total,
-    @JsonKey(name: 'links') required List<PageLink> links,
+    @JsonKey(name: 'links') required List<PageLinkResponse> links,
   }) = _BreedsResponse;
 
   factory BreedsResponse.fromJson(Map<String, dynamic> json) =>
@@ -19,26 +19,27 @@ class BreedsResponse with _$BreedsResponse {
 }
 
 @freezed
-class Breed with _$Breed {
-  const factory Breed({
+class BreedResponse with _$BreedResponse {
+  const factory BreedResponse({
     @JsonKey(name: 'breed') required String breed,
     @JsonKey(name: 'country') required String country,
     @JsonKey(name: 'origin') required String origin,
     @JsonKey(name: 'coat') required String coat,
     @JsonKey(name: 'pattern') required String pattern,
-  }) = _Breed;
+  }) = _BreedResponse;
 
-  factory Breed.fromJson(Map<String, dynamic> json) => _$BreedFromJson(json);
+  factory BreedResponse.fromJson(Map<String, dynamic> json) =>
+      _$BreedResponseFromJson(json);
 }
 
 @freezed
-class PageLink with _$PageLink {
-  const factory PageLink({
+class PageLinkResponse with _$PageLinkResponse {
+  const factory PageLinkResponse({
     @JsonKey(name: 'url') String? url,
     @JsonKey(name: 'label') required String label,
     @JsonKey(name: 'active') required bool active,
-  }) = _PageLink;
+  }) = _PageLinkResponse;
 
-  factory PageLink.fromJson(Map<String, dynamic> json) =>
-      _$PageLinkFromJson(json);
+  factory PageLinkResponse.fromJson(Map<String, dynamic> json) =>
+      _$PageLinkResponseFromJson(json);
 }


### PR DESCRIPTION
## 概要
Breedsの一覧を[WebAPI](https://catfact.ninja/breeds)から取得するための実装を行なった

### 対応内容
- 指定のエンドポイント(https://catfact.ninja/breeds) からBreedsの一覧を取得する部分までの実装を行なった
  - Repositoryの実装
  - アプリ側のレイヤーで使用するためのObjectとしてBreedsを新規に実装

## チェックリスト
- [x] log関数でレスポンスが受け取れていることを確認

## 備考
