### PR TITLE
詳細画面の実装

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_cat_breeds/router/app_route_name.dart';
 import 'package:flutter_cat_breeds/router/app_router.dart';
-import 'package:flutter_cat_breeds/view/home_screen.dart';
+import 'package:flutter_cat_breeds/view/home/home_screen.dart';
 
-class App extends StatelessWidget {
+final class App extends StatelessWidget {
   const App({super.key});
 
   @override

--- a/lib/domain/breed.dart
+++ b/lib/domain/breed.dart
@@ -1,15 +1,14 @@
-class Breed {
-  const Breed({
-    required this.breed,
-    required this.country,
-    required this.origin,
-    required this.coat,
-    required this.pattern,
-  });
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  final String breed;
-  final String country;
-  final String origin;
-  final String coat;
-  final String pattern;
+part '../_generated/domain/breed.freezed.dart';
+
+@freezed
+class Breed with _$Breed {
+  const factory Breed({
+    required String breed,
+    required String country,
+    required String origin,
+    required String coat,
+    required String pattern,
+  }) = _Breed;
 }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_cat_breeds/router/app_route_name.dart';
-import 'package:flutter_cat_breeds/view/home_screen.dart';
+import 'package:flutter_cat_breeds/view/home/home_screen.dart';
+import 'package:flutter_cat_breeds/domain/breed.dart';
+import 'package:flutter_cat_breeds/view/detail/detail_screen.dart';
 
 final class AppRouter {
   static Route<dynamic> generateRoute(RouteSettings settings) {
@@ -9,10 +11,26 @@ final class AppRouter {
     switch (settings.name) {
       case AppRouteName.home:
         builder = const HomeScreen();
+        break;
+
+      case AppRouteName.detail:
+        final args = settings.arguments;
+        if (args is Breed) {
+          builder = DetailScreen(breed: args);
+        } else {
+          builder = const Center(
+            child: Text(
+              'Routing error: AppRouteName.detail には Breed 型の arguments が必要です',
+              style: TextStyle(color: Colors.red),
+              textAlign: TextAlign.center,
+            ),
+          );
+        }
+
       default:
         builder = const Center(
           child: Text(
-            'undifined root',
+            'undefined route',
             style: TextStyle(color: Colors.red),
           ),
         );
@@ -21,7 +39,8 @@ final class AppRouter {
 
     return MaterialPageRoute(
       builder: (_) => builder,
-      settings: RouteSettings(name: settings.name),
+      settings:
+          RouteSettings(name: settings.name, arguments: settings.arguments),
     );
   }
 }

--- a/lib/view/detail/detail_screen.dart
+++ b/lib/view/detail/detail_screen.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_cat_breeds/domain/breed.dart';
+
+final class DetailScreen extends StatelessWidget {
+  const DetailScreen({super.key, required this.breed});
+
+  final Breed breed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(breed.breed),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            Flexible(
+              child: Card(
+                elevation: 3,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          breed.breed,
+                          style: Theme.of(context)
+                              .textTheme
+                              .headlineSmall
+                              ?.copyWith(
+                                fontWeight: FontWeight.bold,
+                              ),
+                        ),
+                        const SizedBox(height: 16),
+                        _InfoRow(label: 'Country', value: breed.country),
+                        _InfoRow(label: 'Origin', value: breed.origin),
+                        _InfoRow(label: 'Coat', value: breed.coat),
+                        _InfoRow(label: 'Pattern', value: breed.pattern),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Center(
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
+                icon: const Icon(Icons.arrow_back),
+                label: const Text('Back to list'),
+                style: ElevatedButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+final class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 100,
+            child: Text(
+              '$label:',
+              style: const TextStyle(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(
+                color: Colors.black87,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/home/home_screen.dart
+++ b/lib/view/home/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_cat_breeds/view/home_view_model.dart';
+import 'package:flutter_cat_breeds/router/app_route_name.dart';
+import 'package:flutter_cat_breeds/view/home/home_view_model.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final class HomeScreen extends ConsumerStatefulWidget {
@@ -22,9 +23,11 @@ final class _HomeScreenState extends ConsumerState<HomeScreen> {
           return ListView.builder(
             itemCount: breeds.length,
             itemBuilder: (context, index) {
-              return Card(
-                child: ListTile(
-                  title: Text(breeds[index].breed),
+              return _ContentCard(
+                title: breeds[index].breed,
+                onTap: () => Navigator.of(context).pushNamed(
+                  AppRouteName.detail,
+                  arguments: breeds[index],
                 ),
               );
             },
@@ -47,6 +50,33 @@ final class _HomeScreenState extends ConsumerState<HomeScreen> {
         ),
         loading: () => const Center(
           child: CircularProgressIndicator(),
+        ),
+      ),
+    );
+  }
+}
+
+final class _ContentCard extends StatelessWidget {
+  const _ContentCard({
+    required this.title,
+    required this.onTap,
+  });
+
+  final String title;
+  final VoidCallback onTap;
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Card(
+        child: InkWell(
+          onTap: onTap,
+          child: Container(
+            alignment: Alignment.center,
+            height: 100,
+            width: double.infinity,
+            child: Text(title),
+          ),
         ),
       ),
     );

--- a/lib/view/home/home_view_model.dart
+++ b/lib/view/home/home_view_model.dart
@@ -2,7 +2,7 @@ import 'package:flutter_cat_breeds/domain/breed.dart';
 import 'package:flutter_cat_breeds/model/breeds_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part '../_generated/view/home_view_model.g.dart';
+part '../../_generated/view/home/home_view_model.g.dart';
 
 @riverpod
 class HomeViewModel extends _$HomeViewModel {


### PR DESCRIPTION
## 概要
Breedの詳細情報が確認できるが画面を実装した

### 対応内容
- 詳細画面の実装
- Routerで引数を取れるような形への修正
- BreedのObjectをfreezedを使用したものに修正
- ディレクトリ構成の修正

## テスト手順
再現手順および確認手順を記載してください

## スクリーンショット
UI変更がある場合は添付してください

| 項目 | スクリーンショット |
|:--:|:--:|
| タイトル | <video src="https://github.com/user-attachments/assets/f21f1d22-fade-4d17-a596-e3a1e667980e" width="320px"> |

## チェックリスト
- [x] 詳細画面へHome画面のリストをタップすると遷移できること
- [x] 詳細画面のナビゲーションバーの戻るボタンでリストに戻れること
- [x] 詳細画面の「Back to list」ボタンでリストに戻れること