### PR TITLE
エラー画面の文言を英語に統一

### DIFF
--- a/lib/view/home/home_screen.dart
+++ b/lib/view/home/home_screen.dart
@@ -37,13 +37,13 @@ final class _HomeScreenState extends ConsumerState<HomeScreen> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text('エラーが発生しました'),
+              const Text('An error occurred'),
               const SizedBox(height: 8),
               ElevatedButton(
                 onPressed: () {
                   ref.invalidate(homeViewModelProvider);
                 },
-                child: const Text('再読み込み'),
+                child: const Text('Retry'),
               ),
             ],
           ),


### PR DESCRIPTION
## 概要
アプリ全体の文言の統一のため

### 対応内容
- 文言を英語に修正

## スクリーンショット

| 項目 | スクリーンショット |
|:--:|:--:|
| タイトル | <img src="https://github.com/user-attachments/assets/10aaa69b-3958-46a2-8e7a-9f1f21f4e3ab" width="320px"> |

<img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-10-05 at 13 25 46" src="" />

## チェックリスト
- [x] エラー時の文言が英語になっている
